### PR TITLE
Header

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
-title: "Front-End Engineering Curriculum - Turing School of Software and Design"
-description: "Open source curriculum for the Turing School of Software and Design's front end engineering program."
+title: "Mod 5 Engineering Curriculum - Turing School of Software and Design"
+description: "Open source curriculum for the Turing School of Software and Design's Mod 5."
 url: "http://frontend.turing.io/"
 
 baseurl: ''

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,8 +6,7 @@
          alt="Turing School of Software and Design logo">
       </a>
     </li>
-    <li class="uppercase"><a href="/page_1">Page 1</a></li>
-    <li class="uppercase"><a href="/page_2">Page 2</a></li>
+    <li class="uppercase"><a href="/job_squad">Job Squad</a></li>
     <li class="uppercase"><a href="/calendar">Calendar</a></li>
   </ul>
 </nav>

--- a/_sass/navbar.scss
+++ b/_sass/navbar.scss
@@ -6,7 +6,7 @@ nav {
 
 .nav-links {
   display: grid;
-  grid-template-columns: auto 100px 100px 100px 200px;
+  grid-template-columns: auto 100px 100px;
   grid-template-rows: 120px;
   align-items: center;
   justify-items: center;


### PR DESCRIPTION
Browser tab has been updated from FE to Mod 5.

Header has been updated to only hold two links:
- Job Squad
- Calendar

The Job Squad link is currently taking the user to a 404, Rachel will be building that page out later.  In `navigation.html` the link is currently pointing to `<a href="/job_squad">`.