### PR TITLE
Move interview prep to home page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
-title: "Front-End Engineering Curriculum - Turing School of Software and Design"
-description: "Open source curriculum for the Turing School of Software and Design's front end engineering program."
+title: "Mod 5 Engineering Curriculum - Turing School of Software and Design"
+description: "Open source curriculum for the Turing School of Software and Design's Mod 5."
 url: "http://frontend.turing.io/"
 
 baseurl: ''

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,8 +6,7 @@
          alt="Turing School of Software and Design logo">
       </a>
     </li>
-    <li class="uppercase"><a href="/page_1">Page 1</a></li>
-    <li class="uppercase"><a href="/page_2">Page 2</a></li>
+    <li class="uppercase"><a href="/job_squad">Job Squad</a></li>
     <li class="uppercase"><a href="/calendar">Calendar</a></li>
   </ul>
 </nav>

--- a/_sass/navbar.scss
+++ b/_sass/navbar.scss
@@ -6,7 +6,7 @@ nav {
 
 .nav-links {
   display: grid;
-  grid-template-columns: auto 100px 100px 100px 200px;
+  grid-template-columns: auto 100px 100px;
   grid-template-rows: 120px;
   align-items: center;
   justify-items: center;

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@ title: Home
   <p>Some copy?</p>
 
   <a class="btn btn-dark" href="/job_search_care_package">Job Search Care Package</a>
+  <a href="btn btn-dark" href="/interview_prep">Interview Prep</a>
   <a class="btn btn-dark" href="/curriculum">Curriculum</a>
   <a class="btn btn-dark" href="/homework">Homework</a>
   <a class="btn btn-dark" href="/calendar">Calendar</a>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ title: Home
   <p>Some copy?</p>
 
   <a class="btn btn-dark" href="/job_search_care_package">Job Search Care Package</a>
-  <a href="btn btn-dark" href="/interview_prep">Interview Prep</a>
+  <a class="btn btn-dark" href="/interview_prep">Interview Prep</a>
   <a class="btn btn-dark" href="/curriculum">Curriculum</a>
   <a class="btn btn-dark" href="/homework">Homework</a>
   <a class="btn btn-dark" href="/calendar">Calendar</a>

--- a/interview_prep/index.html
+++ b/interview_prep/index.html
@@ -1,0 +1,145 @@
+---
+layout: page
+title: Interview Prep
+---
+
+<h2>Interview Prep Resources</h2>
+<h3>Your interview process with tech companies will comprise of two main components: the technical interivew and the behavioral interview. Below you can find lots of resources to help you prepare for both components.</h3>
+
+<section>
+  <button class="btn btn-dark week-selector" data-week="technical-interview">The Technical Interview</button>
+  <button class="btn btn-dark week-selector" data-week="behavioral-interview">The Behavioral Interview</button>
+</section>
+
+<section class="week-content" data-week="technical-interview">
+  <h2>Technical Interview Prep Resources</h2>
+  <h3>Start Here</h3>
+  <ul>
+    <li><a href="https://techinterview.guide">Ian Douglas' Guide to Technical Interview Prep</a></li>
+    <li>Join Ian Douglas' mailing list at <a href="https://iandouglas.com/interview-prep/">his site</a> for interview prep emails</li>
+    <li><a href="https://yangshun.github.io/tech-interview-handbook/">Tech Interview Handbook</a> by Yangshun Tay and Louie Tan</li>
+    <ul>
+      <li><a href="https://yangshun.github.io/tech-interview-handbook/coding-round-overview/#!">Preparing for a Coding Interview</a></li>
+      <li><a href="https://yangshun.github.io/tech-interview-handbook/cheatsheet/">Interview Cheat Sheet</a></li>
+      <li><a href="https://www.fullstackinterviewing.com/2018/02/02/the-ultimate-guide-to-kicking-ass-on-take-home-coding-challenges.html">Ultimate Guide to Kicking Ass on Take-home Coding Challenges</a></li>
+    </ul>
+    <li>Check out one of Ian's <a href="https://www.youtube.com/watch?v=aXohtMcPT6I">Google Hangout sessions on interviewing</a></li>
+  </ul>
+  <h3>Practice</h3>
+  <ul>
+    <li>Schedule a mock interview with one of the following mentors who have been trained on giving technical interviews:</li>
+    <ul>
+      <li>Rich Shea - DM Rich on Slack (@richshea) to schedule an interview slot</li>
+      <li><a href="https://austinwood.youcanbook.me/">Austin Wood</a></li>
+      <li><a href="https://joshcass.youcanbook.me/">Josh Cass</a></li>
+      <li><a href="https://calendly.com/adriennedomingus/">Adrienne Domingus</a> - if you do not see a time that works for you, feel free to reach out to Adrienne on Slack (@adrienne)</li>
+      <li><a href="https://judsonstevens.youcanbook.me">Judson Stevens</a></li>
+      <li><a href="https://calendly.com/timomitchel23">Tim Tyrell</a></li>
+      <li><a href="https://adrian-lara.youcanbook.me/">Adrian Lara</a></li>
+    </ul>
+    <li><a href="https://www.pramp.com/#/">Pramp</a> is a free site to practice technical interviews with a peer. Use the promo code at <a href="https://www.pramp.com/promo/iandouglas">https://www.pramp.com/promo/iandouglas</a> to get unlimited mock interview credits</li>
+    <li><a href="https://interviewing.io/">Interviewing.io</a> allows you to do anonymous mock interviews from top companies. You can also watch recordings of past interviews!</li>
+    <li><a href="https://www.meetup.com/denver-tech-interview-meetup/">Denver Tech Interview Meetup</a> is held twice a month, either downtown or in the Denver Tech Center</li>
+    <li>Coding challenges resources:</li>
+    <ul>
+      <li><a href="https://github.com/turingschool/challenges">Turing challenges</a></li>
+      <li><a href="https://www.codewars.com/">Code Wars</a></li>
+      <li><a href="http://exercism.io/languages/">Exercisms</a></li>
+      <li><a href="https://www.hackerrank.com/dashboard">HackerRank</a></li>
+      <li><a href="https://codesignal.com/">CodeSignal</a></li>
+    </ul>
+  </ul>
+  <h3>Other Resources</h3>
+  <li><a href="https://simpleprogrammer.com/programming-interview-questions/">Top 50 Programming Interview Questions</a></li>
+  <li><a href="https://yangshun.github.io/tech-interview-handbook/algorithms/algorithms-introduction/">Algorithm Questions</a></li>
+  <li><a href="https://techtion.co/?ref=producthunt">Tech Interview Questions Directory</a></li>
+  <li><a href="https://www.toptal.com/ruby/interview-questions">Essential Ruby Interview Questions</a></li>
+  <li><a href="https://www.codementor.io/blog/ruby-on-rails-interview-questions-du107w0ss?icn=post-3ey8yl7epg&ici=post-du107w0ss">List of Ruby on Rails questions</a></li>
+  <li><a href="https://github.com/yangshun/front-end-interview-handbook">Front End Interview Handbook</a></li>
+  <li><a href="https://www.codementor.io/nihantanu/21-essential-javascript-tech-interview-practice-questions-answers-du107p62z?icn=post-3ey8yl7epg&ici=post-du107p62z">Essential JavaScript questions</a></li>
+  <li><a href="https://www.edureka.co/blog/interview-questions/react-interview-questions/?utm_source=mybridge&utm_medium=blog&utm_campaign=read_more">Top 50 React Interview Prep Questions</a></li>
+  <li><a href="https://www.codementor.io/blog/5-essential-reactjs-interview-questions-du1084ym1?icn=post-3ey8yl7epg&ici=post-du1084ym1">Additional React Questions</a></li>
+  <li><a href="https://www.codementor.io/blog/angularjs-interview-questions-sample-answers-du1081n7p?icn=post-3ey8yl7epg&ici=post-du1081n7p">Essential Angular Questions</a></li>
+  <li><a href="https://www.codementor.io/sheena/essential-python-interview-questions-du107ozr6?icn=post-3ey8yl7epg&ici=post-du107ozr6">Essential Python Questions</a></li>
+  <li><a href="https://www.codementor.io/blog/java-interview-sample-questions-answers-du107xs23?icn=post-3ey8yl7epg&ici=post-du107xs23">Essential Java Questions</a></li>
+  <li>Read about the <a href="https://airtable.com/shr3eGPDm3wGjT2gA/tbluCbToxQ2knSLhh/viwmFR062GOjG4cjs">interview process at over 500 companies</a></li>
+</section>
+
+<section class="week-content" data-week="behavioral-interview">
+  <h2>Behavioral Interview Prep Resources</h2>
+  <h3>Start Here</h3>
+  <ul>
+    <li><a href="https://yangshun.github.io/tech-interview-handbook/behavioral-questions/">Behavioral Interview Formats and Questions to Review</a></li>
+    <li><a href="https://blog.pramp.com/the-interviewers-perspective-how-to-answer-why-should-i-hire-you-ad070987c2cc">How to Answer "Why Should I Hire You?"</a></li>
+  </ul>
+  <h3>Bank of Common Questions</h3>
+  <h4>Storytelling, Experience, and Career Goals Questions:</h4>
+  <ul>
+    <li>Tell me about yourself. Why do you want to be a software developer?</li>
+    <li>Tell me about your journey into tech. How did you get interested in coding, and why was software development a good fit for you? How is that applicable to our _____ role or company goals?</li>
+    <li>What made you switch from your prior career into programming?</li>
+    <li>Describe your background. How did you get to where you are now? What was your previous career field? What did you like about it? What didn’t you like about it? Why coding?</li>
+    <li>Describe your coding experience and why you wish to continue.</li>
+    <li>What are you looking for in a company? Why would you want to work here?</li>
+    <li>Describe your time at Turing. How did it prepare you for this career?</li>
+    <li>What is your 100% ideal role for your first web development job?</li>
+    <li>Have you ever worked directly with clients or have been in a customer-facing role in the past? If not, would you like to?</li>
+    <li>Talk about your preferred development environment.</li>
+    <li>How are you keeping up with the latest developments in web development?</li>
+  </ul>
+  <h4>Project, Problem-Solving, & Team Contribution Questions:</h4>
+  <ul>
+    <li>Describe a successful idea or project you worked on. What are some of the challenges you had to overcome? What made it a success?</li>
+    <li>Describe a project that failed, a project you had to give up on, or a time you worked really hard on a project and it just didn’t pan out as expected. What happened? How did you make the decisions that you made?</li>
+    <li>When have you solved a problem that didn’t involve you coding?</li>
+    <li>Please describe to me the difference between waterfall and agile approaches to software.</li>
+    <li>How have you implemented or adapted agile practices in your projects?</li>
+    <li>What is your approach to working on a team?</li>
+    <li>A lot of this job will be full-stack. Your experience is largely ____ (Back End, Front End). How do you feel like you’d be able to contribute to the team with only that experience? How comfortable are you with getting uncomfortable with a new language?</li>
+    <li>Describe an example of how you have handled a stressful situation.</li>
+    <li>In what types of environments/projects is it best to use pair programming? Why? In what cases would you not use pair programming? Why?</li>
+    <li>Describe your teamwork experience in a coding environment. How big of a team did you work with?</li>
+    <li>Have you ever had to switch gears in the middle of a project to get something fixed immediately? How did you react?</li>
+    <li>What project of yours are you most proud of and why?</li>
+    <li>You can’t work out how to solve a coding problem. What do you do to find the answer?</li>
+    <li>Tell me about a challenge or conflict you've faced at work and how you dealt with it.</li>
+    <li>How do you approach testing? And what do you think about this? How would you improve QA?</li>
+    <li>When have you exercised leadership and what was the result?</li>
+    <li>Describe a time when you took a risk that paid off for you. What was your process for pushing yourself further? How did you assess risk and try something new?</li>
+  </ul>
+  <h4>Communication & Feedback Questions:</h4>
+  <ul>
+    <li>Describe to me the steps you would take to build out a product.</li>
+    <li>Tell me how you solve a problem.</li>
+    <li>Explain one of the most difficult code problems you’ve had to solve, either on your own authored code, or in contributing to someone else’s.</li>
+    <li>Tell me about a time you had a disagreement with a colleague and how you resolved it.</li>
+    <li>Describe a time when you received feedback that you were surprised by. What did you do with that feedback?</li>
+    <li>When you disagree with a decision your team makes, how do you handle it?</li>
+  </ul>
+  <h4>Personal Growth & Self-Awareness Questions:</h4>
+  <ul>
+    <li>What is an area of growth for you?</li>
+    <li>What’s hard about programming?</li>
+    <li>What are some of your best professional/soft skills?</li>
+    <li>Describe your strengths. How have you seen these in practice as a developer?</li>
+    <li>How do you deal with failure?</li>
+    <li>What is your biggest weakness?</li>
+    <li>What is your greatest professional achievement/achievement at Turing so far? Why?</li>
+    <li>Where do you see yourself in 5 years?</li>
+    <li>How would your former boss/current classmates/instructors describe you?</li>
+    <li>When have you taken accountability for something even when it could have proven detrimental for you?</li>
+  </ul>
+  <h3>Practice</h3>
+  <ul>
+    <li>Schedule a mock behavioral interview with one of the following people:</li>
+    <ul>
+      <li>Allison Reu Singer: DM her on Slack @allison_reu_singer</li>
+      <li>Kayt Hensley: Sign up using <a href="https://calendly.com/kaythensley">this link</a></li>
+    </ul>
+  </ul>
+  <h3>Questions to Ask the Interview & Other Resources</h3>
+  <ul>
+    <li><a href="https://yangshun.github.io/tech-interview-handbook/questions-to-ask/">Questions to Ask the Interviewer</a></li>
+    <li><a href="https://www.keyvalues.com/culture-queries">Tool to Help You Come Up with Culture Questions</a></li>
+  </ul>
+</section>

--- a/job_search_care_package/index.html
+++ b/job_search_care_package/index.html
@@ -9,7 +9,6 @@ title: Job Search Care Package
   <button class="btn btn-dark week-selector" data-week="resumes-cover-letters">Resumes & Cover Letters</button>
   <button class="btn btn-dark week-selector" data-week="finding-job-opportunities">Finding Job Opportunities</button>
   <button class="btn btn-dark week-selector" data-week="outreach-networking">Outreach & Networking</button>
-  <button class="btn btn-dark week-selector" data-week="interview-prep">Interview Prep</button>
   <button class="btn btn-dark week-selector" data-week="github">Your GitHub</button>
   <button class="btn btn-dark week-selector" data-week="mscl">Miscellaneous</button>
 </section>
@@ -201,11 +200,6 @@ title: Job Search Care Package
       <li><a href="https://www.transtechsocial.org/">Trans Tech Social Enterprises</a> is an incubator for LGBTQ Talent with a focus on economically empowering transgender people.</li>
     </ul>
   </article>
-</section>
-
-<section class="week-content" data-week="interview-prep">
-  <h2>Interview Prep</h2>
-  <p><a href="https://github.com/turingschool/career-development-curriculum/blob/master/module_four/interview_prep_resources.md">Use this resources doc</a> to find <b>LOTS</b> of interviewing resources including <b>MULTIPLE</b> mentors who you can have mock interviews with!</p>
 </section>
 
 <section class="week-content" data-week="github">


### PR DESCRIPTION
This PR: 
1. removes the Interview Prep button from the Job Search Care Package page
2. Adds a Interview Prep button on the home page
3. Adds an Interview Prep page that includes the content from the original Interview Prep Markdown.
<img width="1439" alt="Screen Shot 2019-12-05 at 1 56 58 PM" src="https://user-images.githubusercontent.com/8812335/70273522-7d54c800-1767-11ea-8265-db9da2591ef8.png">
<img width="1439" alt="Screen Shot 2019-12-05 at 1 58 28 PM" src="https://user-images.githubusercontent.com/8812335/70273530-804fb880-1767-11ea-9a39-e497aab786fb.png">
<img width="1437" alt="Screen Shot 2019-12-05 at 1 58 50 PM" src="https://user-images.githubusercontent.com/8812335/70273554-8a71b700-1767-11ea-8cc8-38bad333084b.png">

<img width="1436" alt="Screen Shot 2019-12-05 at 1 58 43 PM" src="https://user-images.githubusercontent.com/8812335/70273544-86459980-1767-11ea-8670-e8fee4fb1c88.png">
